### PR TITLE
Fixed 17 issues of type: PYTHON_E402 throughout 2 files in repo.

### DIFF
--- a/datasets/prep_oi4.py
+++ b/datasets/prep_oi4.py
@@ -1,8 +1,3 @@
-if __name__ == '__main__' and __package__ is None:
-    import sys
-    from os import path
-    sys.path.append(path.dirname(path.dirname(path.abspath(__file__))))
-
 import argparse
 import os
 import cv2
@@ -11,8 +6,13 @@ import hashlib
 from PIL import Image
 import numpy as np
 import pandas as pd
-
 from common.logger_utils import initialize_logging
+if __name__ == '__main__' and __package__ is None:
+    import sys
+    from os import path
+    sys.path.append(path.dirname(path.dirname(path.abspath(__file__))))
+
+
 
 
 def parse_args():

--- a/datasets/prep_oi4bb.py
+++ b/datasets/prep_oi4bb.py
@@ -1,8 +1,3 @@
-if __name__ == '__main__' and __package__ is None:
-    import sys
-    from os import path
-    sys.path.append(path.dirname(path.dirname(path.abspath(__file__))))
-
 import argparse
 import os
 import zipfile
@@ -10,8 +5,13 @@ import logging
 import shutil
 import numpy as np
 import pandas as pd
-
 from common.logger_utils import initialize_logging
+if __name__ == '__main__' and __package__ is None:
+    import sys
+    from os import path
+    sys.path.append(path.dirname(path.dirname(path.abspath(__file__))))
+
+
 
 
 def parse_args():


### PR DESCRIPTION
PYTHON_E402: 'module level import not at top of file'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.

It was fixed with <a href='https://github.com/hhatto/autopep8'>autopep8</a>.  The fix is completely safe.