### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,6 @@ Pillow
 imgaug
 scipy
 tqdm
+Cython
+numpy
 pycocotools


### PR DESCRIPTION
pycocotools requires numpy and Cython but doesn't automatically attempt to install them