### PR TITLE
Remove numpy from line 17

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,5 +15,4 @@ imgaug
 scipy
 tqdm
 Cython
-numpy
 pycocotools


### PR DESCRIPTION
Numpy was already included, pip install -r requirements.txt will still fail because of a problem in the Pycoco setup.py script. This is probably a Pycoco issue but the work around for this repository is to remove pycocotools from requirements.txt and to install pycocotools after pip has installed all the collected packages.