### PR TITLE
Fix res2net Gluon implementation preactive channels

### DIFF
--- a/gluon/gluoncv2/models/res2net.py
+++ b/gluon/gluoncv2/models/res2net.py
@@ -135,7 +135,7 @@ class Res2NetUnit(HybridBlock):
                 out_channels=out_channels,
                 bn_use_global_stats=bn_use_global_stats,
                 activation=None)
-            self.preactiv = PreActivation(in_channels=out_channels)
+            self.preactiv = PreActivation(in_channels=mid_channels)
             if self.resize_identity:
                 self.identity_conv = conv1x1_block(
                     in_channels=in_channels,


### PR DESCRIPTION
The number of input channels for the `preactiv` block in `Res2NetUnit` is wrong.

As you can see [in `res2net.py` on line 138](https://github.com/osmr/imgclsmob/blob/306fa332f70538e95a37767dff265d1ecb76c7d6/gluon/gluoncv2/models/res2net.py#L138), the number of input channels is set to `out_channels`, but when this block is used [on line 155](https://github.com/osmr/imgclsmob/blob/306fa332f70538e95a37767dff265d1ecb76c7d6/gluon/gluoncv2/models/res2net.py#L155), the input is the output of `branches`, which is supposed to have `mid_channels` output channels.

This inconsistency can cause a `Deferred initialization` error.