### PR TITLE
Add decorator @add_get_config in tensorflow2/tf2cv/models/common.py

### DIFF
--- a/tensorflow2/tf2cv/models/common.py
+++ b/tensorflow2/tf2cv/models/common.py
@@ -19,6 +19,50 @@ import tensorflow as tf
 import tensorflow.keras.layers as nn
 
 
+#add below func
+import inspect
+import types
+
+def get_config(self):
+    """
+    
+    This func implements get_config() method
+    which is inevitable when save and load models.
+
+    Parameters:
+    ----------
+    None
+    """
+    
+    self.config = super(self.__class__, self).get_config()
+    self.config.update(self.argdict)
+    return self.config
+
+def add_get_config(f):
+    """
+    
+    This decorator dynamically add get_config() method.
+    This must add class.__init__() method 
+
+    Parameters:
+    ----------
+    f : python function, decorate class's __init__() method
+    
+    """
+    
+    def wrapper(*args, **kwargs):
+        signatures = list(inspect.signature(f).parameters.keys())
+        argdict = {sig:arg for sig,arg in zip(signatures[1:],args[1:])}
+        argdict.update(kwargs)
+        object.__setattr__(args[0], 'argdict', argdict)
+        
+        f(*args, **kwargs)
+        #override get_config()
+        object.__setattr__(args[0], 'get_config',  types.MethodType( get_config, args[0] ) )
+        
+    return wrapper
+
+
 def is_channels_first(data_format):
     """
     Is tested data format channels first.
@@ -1046,6 +1090,7 @@ class ConvBlock(nn.Layer):
     data_format : str, default 'channels_last'
         The ordering of the dimensions in tensors.
     """
+    @add_get_config
     def __init__(self,
                  in_channels,
                  out_channels,

--- a/tensorflow2/tf2cv/models/efficientnet.py
+++ b/tensorflow2/tf2cv/models/efficientnet.py
@@ -18,6 +18,7 @@ import tensorflow as tf
 import tensorflow.keras.layers as nn
 from .common import round_channels, conv1x1_block, conv3x3_block, dwconv3x3_block, dwconv5x5_block, SEBlock,\
     is_channels_first
+from .common import add_get_config
 
 
 def calc_tf_padding(x,
@@ -80,6 +81,7 @@ class EffiDwsConvUnit(nn.Layer):
     data_format : str, default 'channels_last'
         The ordering of the dimensions in tensors.
     """
+    @add_get_config
     def __init__(self,
                  in_channels,
                  out_channels,
@@ -156,6 +158,7 @@ class EffiInvResUnit(nn.Layer):
     data_format : str, default 'channels_last'
         The ordering of the dimensions in tensors.
     """
+    @add_get_config
     def __init__(self,
                  in_channels,
                  out_channels,
@@ -244,6 +247,7 @@ class EffiInitBlock(nn.Layer):
     data_format : str, default 'channels_last'
         The ordering of the dimensions in tensors.
     """
+    @add_get_config
     def __init__(self,
                  in_channels,
                  out_channels,
@@ -307,6 +311,7 @@ class EfficientNet(tf.keras.Model):
     data_format : str, default 'channels_last'
         The ordering of the dimensions in tensors.
     """
+    @add_get_config
     def __init__(self,
                  channels,
                  init_block_channels,

--- a/tensorflow2/tf2cv/models/resnet.py
+++ b/tensorflow2/tf2cv/models/resnet.py
@@ -12,6 +12,7 @@ import os
 import tensorflow as tf
 import tensorflow.keras.layers as nn
 from .common import conv1x1_block, conv3x3_block, conv7x7_block, MaxPool2d, flatten, is_channels_first
+from .common import add_get_config
 
 
 class ResBlock(nn.Layer):
@@ -226,6 +227,7 @@ class ResInitBlock(nn.Layer):
     data_format : str, default 'channels_last'
         The ordering of the dimensions in tensors.
     """
+    @add_get_config
     def __init__(self,
                  in_channels,
                  out_channels,

--- a/tensorflow2/tf2cv/models/resnext.py
+++ b/tensorflow2/tf2cv/models/resnext.py
@@ -12,6 +12,7 @@ import math
 import tensorflow as tf
 import tensorflow.keras.layers as nn
 from .common import conv1x1_block, conv3x3_block, flatten
+from .common import add_get_config
 from .resnet import ResInitBlock
 
 
@@ -36,6 +37,7 @@ class ResNeXtBottleneck(nn.Layer):
     data_format : str, default 'channels_last'
         The ordering of the dimensions in tensors.
     """
+    @add_get_config
     def __init__(self,
                  in_channels,
                  out_channels,
@@ -95,6 +97,7 @@ class ResNeXtUnit(nn.Layer):
     data_format : str, default 'channels_last'
         The ordering of the dimensions in tensors.
     """
+    @add_get_config
     def __init__(self,
                  in_channels,
                  out_channels,
@@ -158,6 +161,7 @@ class ResNeXt(tf.keras.Model):
     data_format : str, default 'channels_last'
         The ordering of the dimensions in tensors.
     """
+    @add_get_config
     def __init__(self,
                  channels,
                  init_block_channels,


### PR DESCRIPTION
@add_get_config decorator dynamically add get_config() method to existing class object.
@add_get_config provides us easy way to add get_config() method which must implement when save and load models in tensorflow/keras.

We can save and load tensorflow/keras models trained from tf2cv weights, by just adding @add_get_config decorator to layer class's __init__().

But, this pull request only added it's decorator to below models:
 - efficientnet.py
 - resnet.py
 - resnext.py

This is my first pull request on github, sorry for if this request have any problem.